### PR TITLE
Correct bug that prevented "also at" from being assigned a list.

### DIFF
--- a/generic/pgf/frontendlayer/tikz/libraries/datavisualization/tikzlibrarydatavisualization.code.tex
+++ b/generic/pgf/frontendlayer/tikz/libraries/datavisualization/tikzlibrarydatavisualization.code.tex
@@ -606,7 +606,7 @@
 % Ticks at
 \tikzdatavisualizationset{
   at/.code={\def\tikz@dv@at@list{#1}},
-  also at/.code={\expandafter\def\expandafter\tikz@dv@at@list\expandafter{\tikz@dv@at@list,{#1}}},
+  also at/.code={\expandafter\def\expandafter\tikz@dv@at@list\expandafter{\tikz@dv@at@list,#1}},
   major at/.style={major={at={#1}}},
   minor at/.style={minor={at={#1}}},
   subminor at/.style={subminor={at={#1}}},


### PR DESCRIPTION
Hello,
I believe the MWE below shows a contradiction between the PGF manual and the behaviour of the "also at" key for grids in datavisualizations, viz that this key may be assigned a list. The proposed commit makes the MWE compile, is it the right way to do it ?
cheers,
Adrian

The following MWE contains three graphs. The first is copied from the
pgfmanual 3.0.1a p798. The third merely replaces "at" by "also at",
which should be allowed according to the manual p799 ("also at" can be
fed a list just as "at"), but compilation fails on this third graph with
a

Package PGF Math Error: Could not parse input '1, 1.5,
2' as a floating point number, sorry. The unreadable part was near the
decimal separator ', 1.5, 2'. Do you need the option 'read comma as
period'?

\documentclass{scrartcl}
\usepackage{tikz}
\usetikzlibrary{datavisualization}
\usetikzlibrary{datavisualization.formats.functions}

\begin{document}

\tikz \datavisualization
[ school book axes, visualize as smooth line,
x axis={grid={minor={at={1, 1.5, 2}}}}]
data [format=function] {
var x : interval [-1.25:2];
func y = \value x * \value x / 2;
};

\tikz \datavisualization
[ school book axes, visualize as smooth line,
x axis={grid={minor={also at={1}, also at={1.5}, also at={2}}}}]
data [format=function] {
var x : interval [-1.25:2];
func y = \value x * \value x / 2;
};

\tikz \datavisualization
[ school book axes, visualize as smooth line,
x axis={grid={minor={also at={1, 1.5, 2}}}}]
data [format=function] {
var x : interval [-1.25:2];
func y = \value x * \value x / 2;
};

\end{document}